### PR TITLE
Provide relative path in offense message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pronto-punchlist (0.1.0)
+    pronto-punchlist (0.1.1)
       pronto
       punchlist (>= 1.3.0)
 

--- a/lib/pronto/punchlist/offense_matcher.rb
+++ b/lib/pronto/punchlist/offense_matcher.rb
@@ -24,7 +24,7 @@ module Pronto
       def inspect_line(line)
         return nil unless line.new_lineno == @offense.line_num
 
-        @message_creator.create(@offense.filename, line)
+        @message_creator.create(line.patch.delta.new_file[:path], line)
       end
     end
   end

--- a/lib/pronto/punchlist/version.rb
+++ b/lib/pronto/punchlist/version.rb
@@ -2,6 +2,6 @@
 
 module Pronto
   module PunchlistVersion
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/spec/pronto/punchlist/offense_matcher_spec.rb
+++ b/spec/pronto/punchlist/offense_matcher_spec.rb
@@ -19,12 +19,17 @@ describe Pronto::Punchlist::OffenseMatcher do
 
     let(:message) { instance_double(Pronto::Message, 'message') }
     let(:patch) { instance_double(Pronto::Git::Patch, 'patch') }
+    let(:rugged_patch) { instance_double(Rugged::Patch, 'rugged_patch') }
+
     let(:start_of_change_line) { 5 }
     let(:middle_of_change_line) { 6 }
     let(:end_of_change_line) { 7 }
     let(:after_end_of_change_line) { 8 }
     let(:commit_sha) { instance_double(String, 'commit_sha') }
     let(:new_file_full_path) { instance_double(String, 'new_file_full_path') }
+    let(:new_file_path) { instance_double(String, 'new_file_path') }
+    let(:delta) { instance_double(Rugged::Diff::Delta, 'delta') }
+    let(:new_file) { { path: new_file_path } }
 
     let(:start_of_change_line_obj) do
       instance_double(Pronto::Git::Line,
@@ -48,7 +53,7 @@ describe Pronto::Punchlist::OffenseMatcher do
     end
 
     before do
-      allow(message_creator).to receive(:create).with(new_file_full_path,
+      allow(message_creator).to receive(:create).with(new_file_path,
                                                       patch_line_obj) do
         message
       end
@@ -72,6 +77,9 @@ describe Pronto::Punchlist::OffenseMatcher do
       allow(offense).to receive(:line_num) { offense_line }
       allow(offense).to receive(:filename) { new_file_full_path }
       allow(patch).to receive(:new_file_full_path) { new_file_full_path }
+      allow(patch_line_obj).to receive(:patch) { rugged_patch }
+      allow(rugged_patch).to receive(:delta) { delta }
+      allow(delta).to receive(:new_file) { new_file }
     end
 
     context 'when related to patch' do


### PR DESCRIPTION
It looks like the GitHub formatter (at least) won't report on an issue if we provide the absolute path.  This is, for instance, what pronto-rubocop does.  Unfortunately, the convenience method to pull this is private:
https://github.com/prontolabs/pronto/blob/master/lib/pronto/git/patch.rb#L42

See https://github.com/prontolabs/pronto/issues/366